### PR TITLE
Update dependencies, Apply some good practices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/xemwebe/yahoo_finance_api"
 readme = "README.md"
 keywords = ["finance", "yahoo", "stock", "quote"]
 categories = ["api-bindings"]
+include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [dependencies]
 reqwest = { version = "0.11", features = ["json", "rustls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["finance", "yahoo", "stock", "quote"]
 categories = ["api-bindings"]
 
 [dependencies]
-reqwest = { version = "0.10", features = ["json", "rustls"] }
+reqwest = { version = "0.11", features = ["json", "rustls"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 chrono = "0.4"
-tokio-compat-02 = "0.1"
+async-compat = "0.2"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/examples/get_quote.rs
+++ b/examples/get_quote.rs
@@ -1,8 +1,8 @@
-use yahoo_finance_api as yahoo;
-#[cfg(not(feature="blocking"))]
+#[cfg(not(feature = "blocking"))]
 use tokio_test;
+use yahoo_finance_api as yahoo;
 
-#[cfg(not(feature="blocking"))]
+#[cfg(not(feature = "blocking"))]
 fn get_quote() -> Result<f64, yahoo::YahooError> {
     let provider = yahoo::YahooConnector::new();
     // get the latest quotes in 1 minute intervals
@@ -12,7 +12,7 @@ fn get_quote() -> Result<f64, yahoo::YahooError> {
     Ok(quote.close)
 }
 
-#[cfg(feature="blocking")]
+#[cfg(feature = "blocking")]
 fn get_quote() -> Result<f64, yahoo::YahooError> {
     let provider = yahoo::YahooConnector::new();
     // get the latest quotes in 1 minute intervals
@@ -21,7 +21,6 @@ fn get_quote() -> Result<f64, yahoo::YahooError> {
     let quote = response.last_quote()?;
     Ok(quote.close)
 }
-
 
 fn main() {
     let quote = get_quote().unwrap();

--- a/examples/search_ticker.rs
+++ b/examples/search_ticker.rs
@@ -1,32 +1,28 @@
-use yahoo_finance_api as yahoo;
-#[cfg(not(feature="blocking"))]
+#[cfg(not(feature = "blocking"))]
 use tokio_test;
+use yahoo_finance_api as yahoo;
 
-#[cfg(not(feature="blocking"))]
+#[cfg(not(feature = "blocking"))]
 fn search_apple() {
     let provider = yahoo::YahooConnector::new();
     let resp = tokio_test::block_on(provider.search_ticker("AAPL")).unwrap();
 
     println!("All tickers found while searching for 'Apple':");
-    for item in resp.quotes 
-    {
+    for item in resp.quotes {
         println!("{}", item.symbol)
     }
 }
 
-#[cfg(feature="blocking")]
+#[cfg(feature = "blocking")]
 fn search_apple() {
     let provider = yahoo::YahooConnector::new();
     let resp = provider.search_ticker("AAPL").unwrap();
 
     println!("All tickers found while searching for 'Apple':");
-    for item in resp.quotes 
-    {
+    for item in resp.quotes {
         println!("{}", item.symbol)
     }
 }
-
-
 
 fn main() {
     search_apple();

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -81,7 +81,7 @@ async fn send_request(url: &str) -> Result<serde_json::Value, YahooError> {
     let resp = resp.unwrap();
     match resp.status() {
         StatusCode::OK => resp.json().await.map_err(|_|{YahooError::InvalidJson}),
-        status => Err(YahooError::FetchFailed(format!("Status Code: {}", status).to_string())),
+        status => Err(YahooError::FetchFailed(format!("Status Code: {}", status))),
     }
 }
 

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -69,7 +69,6 @@ impl YahooConnector {
         let result = self.search_ticker_opt(name).await?;
         Ok(YSearchResult::from_opt(&result))
     }
-
 }
 
 /// Send request to yahoo! finance server and transform response to JSON value
@@ -80,11 +79,10 @@ async fn send_request(url: &str) -> Result<serde_json::Value, YahooError> {
     }
     let resp = resp.unwrap();
     match resp.status() {
-        StatusCode::OK => resp.json().await.map_err(|_|{YahooError::InvalidJson}),
+        StatusCode::OK => resp.json().await.map_err(|_| YahooError::InvalidJson),
         status => Err(YahooError::FetchFailed(format!("Status Code: {}", status))),
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -170,7 +168,8 @@ mod tests {
     #[test]
     fn test_large_volume() {
         let provider = YahooConnector::new();
-        let response = tokio_test::block_on(provider.get_quote_range("BTC-USD", "1d", "5d")).unwrap();
+        let response =
+            tokio_test::block_on(provider.get_quote_range("BTC-USD", "1d", "5d")).unwrap();
         let quotes = response.quotes().unwrap();
         assert!(quotes.len() > 0usize);
     }
@@ -182,8 +181,7 @@ mod tests {
 
         assert_eq!(resp.count, 15);
         let mut apple_found = false;
-        for item in resp.quotes 
-        {
+        for item in resp.quotes {
             if item.exchange == "NMS" && item.symbol == "AAPL" && item.short_name == "Apple Inc." {
                 apple_found = true;
                 break;
@@ -192,4 +190,3 @@ mod tests {
         assert!(apple_found)
     }
 }
-

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -1,8 +1,8 @@
-
 use super::*;
 
-impl YahooConnector {
+use async_compat::CompatExt;
 
+impl YahooConnector {
     /// Retrieve the quotes of the last day for the given ticker
     pub async fn get_latest_quotes(
         &self,

--- a/src/blocking_impl.rs
+++ b/src/blocking_impl.rs
@@ -32,7 +32,7 @@ impl YahooConnector {
         );
         YResponse::from_json(send_request(&url)?)
     }
- 
+
     /// Retrieve the quote history for the given ticker form date start to end (inklusive), if available; specifying the interval of the ticker.
     pub fn get_quote_history_interval(
         &self,
@@ -63,7 +63,6 @@ impl YahooConnector {
         let result = self.search_ticker_opt(name)?;
         Ok(YSearchResult::from_opt(&result))
     }
-
 }
 
 /// Send request to yahoo! finance server and transform response to JSON value
@@ -74,8 +73,10 @@ fn send_request(url: &str) -> Result<serde_json::Value, YahooError> {
     }
     let resp = resp.unwrap();
     match resp.status() {
-        StatusCode::OK => resp.json().map_err(|_|{YahooError::InvalidJson}),
-        status => Err(YahooError::FetchFailed(format!("Status Code: {}", status).to_string())),
+        StatusCode::OK => resp.json().map_err(|_| YahooError::InvalidJson),
+        status => Err(YahooError::FetchFailed(
+            format!("Status Code: {}", status).to_string(),
+        )),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,9 +159,6 @@ fn main() {
 use chrono::{DateTime, Utc};
 use reqwest::StatusCode;
 
-#[cfg(not(feature = "blocking"))]
-use tokio_compat_02::FutureExt;
-
 mod quotes;
 mod search_result;
 mod yahoo_error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,11 @@
 //! Therefore, the functions need to be called from within another ```async``` function with ```.await``` or via functions like ```block_on```.
 //! The examples are based on the ```tokio``` runtime applying the ```tokio-test``` crate.
 //!
-//! Use the `blocking` feature to get the previous behavior back: i.e. `yahoo_finance_api = {"version": "1.0", features = ["blocking"]}`. 
+//! Use the `blocking` feature to get the previous behavior back: i.e. `yahoo_finance_api = {"version": "1.0", features = ["blocking"]}`.
 //!
-#![cfg_attr(not(feature="blocking"), doc = "
+#![cfg_attr(
+    not(feature = "blocking"),
+    doc = "
 # Get the latest available quote:
 ```rust
 use yahoo_finance_api as yahoo;
@@ -84,8 +86,11 @@ Some fields like `longname` are only optional and will be replaced by default
 values if missing (e.g. empty string). If you do not like this behavior, 
 use `search_ticker_opt` instead which contains `Option<String>` fields, 
 returning `None` if the field found missing in the response.
-")]
-#![cfg_attr(feature="blocking", doc = "
+"
+)]
+#![cfg_attr(
+    feature = "blocking",
+    doc = "
 # Get the latest available quote (with blocking feature enabled):
 ```rust
 use yahoo_finance_api as yahoo;
@@ -154,7 +159,8 @@ fn main() {
     }
 }
 ```
-")]
+"
+)]
 
 use chrono::{DateTime, Utc};
 use reqwest::StatusCode;
@@ -162,23 +168,32 @@ use reqwest::StatusCode;
 mod quotes;
 mod search_result;
 mod yahoo_error;
-pub use quotes::{YResponse, Quote, YChart, YQuoteBlock, YMetaData, TradingPeriod, PeriodInfo, QuoteBlock, AdjClose, QuoteList};
-pub use search_result::{YSearchResultOpt, YQuoteItemOpt, YSearchResult, YQuoteItem, YNewsItem};
+pub use quotes::{
+    AdjClose, PeriodInfo, Quote, QuoteBlock, QuoteList, TradingPeriod, YChart, YMetaData,
+    YQuoteBlock, YResponse,
+};
+pub use search_result::{YNewsItem, YQuoteItem, YQuoteItemOpt, YSearchResult, YSearchResultOpt};
 pub use yahoo_error::YahooError;
 
 const YCHART_URL: &str = "https://query1.finance.yahoo.com/v8/finance/chart";
 const YSEARCH_URL: &str = "https://query2.finance.yahoo.com/v1/finance/search";
 
-// Macros instead of constants, 
+// Macros instead of constants,
 macro_rules! YCHART_PERIOD_QUERY {
-    () => {"{url}/{symbol}?symbol={symbol}&period1={start}&period2={end}&interval={interval}"};
+    () => {
+        "{url}/{symbol}?symbol={symbol}&period1={start}&period2={end}&interval={interval}"
+    };
 }
 macro_rules! YCHART_RANGE_QUERY {
-    () => {"{url}/{symbol}?symbol={symbol}&interval={interval}&range={range}"};
-} 
+    () => {
+        "{url}/{symbol}?symbol={symbol}&interval={interval}&range={range}"
+    };
+}
 macro_rules! YTICKER_QUERY {
-    () => {"{url}?q={name}"};
-} 
+    () => {
+        "{url}?q={name}"
+    };
+}
 
 /// Container for connection parameters to yahoo! finance server
 #[derive(Default)]
@@ -186,7 +201,6 @@ pub struct YahooConnector {
     url: &'static str,
     search_url: &'static str,
 }
-
 
 impl YahooConnector {
     /// Constructor for a new instance of the yahoo  connector.

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -134,8 +134,6 @@ pub struct YMetaData {
     pub valid_ranges: Vec<String>,
 }
 
-
-
 #[derive(Deserialize, Debug)]
 pub struct TradingPeriod {
     pub pre: PeriodInfo,

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -62,8 +62,8 @@ impl YResponse {
         for i in 0..n {
             let timestamp = stock.timestamp[i];
             let quote = stock.indicators.get_ith_quote(timestamp, i);
-            if quote.is_ok() {
-                quotes.push(quote.unwrap());
+            if let Ok(q) = quote {
+                quotes.push(q);
             }
         }
         Ok(quotes)
@@ -170,7 +170,7 @@ impl QuoteBlock {
             return Err(YahooError::EmptyDataSet);
         }
         Ok(Quote {
-            timestamp: timestamp,
+            timestamp,
             open: quote.open[i].unwrap_or(0.0),
             high: quote.high[i].unwrap_or(0.0),
             low: quote.low[i].unwrap_or(0.0),

--- a/src/search_result.rs
+++ b/src/search_result.rs
@@ -55,7 +55,6 @@ pub struct YSearchResult {
     pub news: Vec<YNewsItem>,
 }
 
-
 #[derive(Deserialize, Debug)]
 pub struct YQuoteItem {
     pub exchange: String,
@@ -76,15 +75,23 @@ pub struct YQuoteItem {
 
 impl YQuoteItem {
     fn from_yquote_item_opt(quote: &YQuoteItemOpt) -> YQuoteItem {
-        YQuoteItem{
+        YQuoteItem {
             exchange: quote.exchange.clone(),
-            short_name: quote.short_name.as_ref().unwrap_or(&("".to_string())).clone(),
+            short_name: quote
+                .short_name
+                .as_ref()
+                .unwrap_or(&("".to_string()))
+                .clone(),
             quote_type: quote.quote_type.clone(),
             symbol: quote.symbol.clone(),
             index: quote.index.clone(),
             score: quote.score,
             type_display: quote.type_display.clone(),
-            long_name: quote.long_name.as_ref().unwrap_or(&("".to_string())).clone(),
+            long_name: quote
+                .long_name
+                .as_ref()
+                .unwrap_or(&("".to_string()))
+                .clone(),
             is_yahoo_finance: quote.is_yahoo_finance,
         }
     }
@@ -100,7 +107,7 @@ fn remove_opt(quotes: &[YQuoteItemOpt]) -> Vec<YQuoteItem> {
 
 impl YSearchResult {
     pub fn from_opt(search_result_opt: &YSearchResultOpt) -> YSearchResult {
-        YSearchResult{
+        YSearchResult {
             count: search_result_opt.count,
             quotes: remove_opt(&search_result_opt.quotes),
             news: search_result_opt.news.clone(),


### PR DESCRIPTION
PR divided in multiple commits, each doing something different:
- Update the `reqwest` version, which now uses the `tokio 1.x` runtime
  - Also replace the `tokio-compat-02` crate with `async-compat` which avoids duplicating the `tokio` dependency (the first one relied on the `0.2` version)
- Apply the indications provided by `clippy lint`
- Apply `rustfmt` on the source files
- Add the `include` property in `Cargo.toml` (with the help of `cargo-diet`) which avoids for the library users to download unwanted files