### PR TITLE
Replace blocking client with lighter one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,22 @@ categories = ["api-bindings"]
 include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json", "rustls"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 chrono = "0.4"
-async-compat = "0.2"
+
+# async
+reqwest = { version = "0.11", features = ["json", "rustls"], optional = true }
+async-compat = { version = "0.2", optional = true }
+
+# blocking
+ureq = { version = "2.0", features = ["tls", "json"], default-features = false, optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4"
 
-
 [features]
-blocking = ["reqwest/blocking"]
+default = ["async"]
+
+async = ["reqwest", "async-compat"]
+blocking = ["ureq"]

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use async_compat::CompatExt;
+use reqwest::StatusCode;
 
 impl YahooConnector {
     /// Retrieve the quotes of the last day for the given ticker

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -3,7 +3,24 @@ use super::*;
 use async_compat::CompatExt;
 use reqwest::StatusCode;
 
-impl YahooConnector {
+/// Container for connection parameters to yahoo! finance server
+#[derive(Default)]
+pub struct YahooConnectorAsync {
+    url: &'static str,
+    search_url: &'static str,
+}
+
+impl YahooConnectorAsync {
+    /// Constructor for a new instance of the yahoo  connector.
+    pub fn new() -> Self {
+        Self {
+            url: YCHART_URL,
+            search_url: YSEARCH_URL,
+        }
+    }
+}
+
+impl YahooConnectorAsync {
     /// Retrieve the quotes of the last day for the given ticker
     pub async fn get_latest_quotes(
         &self,
@@ -92,7 +109,7 @@ mod tests {
 
     #[test]
     fn test_get_single_quote() {
-        let provider = YahooConnector::new();
+        let provider = YahooConnectorAsync::new();
         let response = tokio_test::block_on(provider.get_latest_quotes("HNL.DE", "1m")).unwrap();
 
         assert_eq!(&response.chart.result[0].meta.symbol, "HNL.DE");
@@ -103,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_strange_api_responses() {
-        let provider = YahooConnector::new();
+        let provider = YahooConnectorAsync::new();
         let start = Utc.ymd(2019, 7, 3).and_hms_milli(0, 0, 0, 0);
         let end = Utc.ymd(2020, 7, 4).and_hms_milli(23, 59, 59, 999);
         let resp = tokio_test::block_on(provider.get_quote_history("IBM", start, end)).unwrap();
@@ -118,7 +135,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "DeserializeFailed(\"missing field `adjclose`\")")]
     fn test_api_responses_missing_fields() {
-        let provider = YahooConnector::new();
+        let provider = YahooConnectorAsync::new();
         let response = tokio_test::block_on(provider.get_latest_quotes("BF.B", "1m")).unwrap();
 
         assert_eq!(&response.chart.result[0].meta.symbol, "BF.B");
@@ -129,7 +146,7 @@ mod tests {
 
     #[test]
     fn test_get_quote_history() {
-        let provider = YahooConnector::new();
+        let provider = YahooConnectorAsync::new();
         let start = Utc.ymd(2020, 1, 1).and_hms_milli(0, 0, 0, 0);
         let end = Utc.ymd(2020, 1, 31).and_hms_milli(23, 59, 59, 999);
         let resp = tokio_test::block_on(provider.get_quote_history("AAPL", start, end));
@@ -143,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_get_quote_range() {
-        let provider = YahooConnector::new();
+        let provider = YahooConnectorAsync::new();
         let response =
             tokio_test::block_on(provider.get_quote_range("HNL.DE", "1d", "1mo")).unwrap();
         assert_eq!(&response.chart.result[0].meta.symbol, "HNL.DE");
@@ -154,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_get() {
-        let provider = YahooConnector::new();
+        let provider = YahooConnectorAsync::new();
         let start = Utc.ymd(2019, 1, 1).and_hms_milli(0, 0, 0, 0);
         let end = Utc.ymd(2020, 1, 31).and_hms_milli(23, 59, 59, 999);
         let response =
@@ -168,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_large_volume() {
-        let provider = YahooConnector::new();
+        let provider = YahooConnectorAsync::new();
         let response =
             tokio_test::block_on(provider.get_quote_range("BTC-USD", "1d", "5d")).unwrap();
         let quotes = response.quotes().unwrap();
@@ -177,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_search_ticker() {
-        let provider = YahooConnector::new();
+        let provider = YahooConnectorAsync::new();
         let resp = tokio_test::block_on(provider.search_ticker("Apple")).unwrap();
 
         assert_eq!(resp.count, 15);

--- a/src/blocking_impl.rs
+++ b/src/blocking_impl.rs
@@ -67,16 +67,16 @@ impl YahooConnector {
 
 /// Send request to yahoo! finance server and transform response to JSON value
 fn send_request(url: &str) -> Result<serde_json::Value, YahooError> {
-    let resp = reqwest::blocking::get(url);
-    if resp.is_err() {
-        return Err(YahooError::ConnectionFailed);
-    }
-    let resp = resp.unwrap();
-    match resp.status() {
-        StatusCode::OK => resp.json().map_err(|_| YahooError::InvalidJson),
-        status => Err(YahooError::FetchFailed(
-            format!("Status Code: {}", status).to_string(),
-        )),
+    let resp = ureq::get(url).call();
+    if let Ok(resp) = resp {
+        match resp.status() {
+            200 => resp.into_json().map_err(|_| YahooError::InvalidJson),
+            status => Err(YahooError::FetchFailed(
+                format!("Status Code: {}", status),
+            )),
+        }
+    } else {
+        Err(YahooError::ConnectionFailed)
     }
 }
 

--- a/src/blocking_impl.rs
+++ b/src/blocking_impl.rs
@@ -1,6 +1,23 @@
 use super::*;
 
-impl YahooConnector {
+/// Container for connection parameters to yahoo! finance server
+#[derive(Default)]
+pub struct YahooConnectorBlocking {
+    url: &'static str,
+    search_url: &'static str,
+}
+
+impl YahooConnectorBlocking {
+    /// Constructor for a new instance of the yahoo  connector.
+    pub fn new() -> Self {
+        Self {
+            url: YCHART_URL,
+            search_url: YSEARCH_URL,
+        }
+    }
+}
+
+impl YahooConnectorBlocking {
     /// Retrieve the quotes of the last day for the given ticker
     pub fn get_latest_quotes(&self, ticker: &str, interval: &str) -> Result<YResponse, YahooError> {
         self.get_quote_range(ticker, interval, "1d")
@@ -71,9 +88,7 @@ fn send_request(url: &str) -> Result<serde_json::Value, YahooError> {
     if let Ok(resp) = resp {
         match resp.status() {
             200 => resp.into_json().map_err(|_| YahooError::InvalidJson),
-            status => Err(YahooError::FetchFailed(
-                format!("Status Code: {}", status),
-            )),
+            status => Err(YahooError::FetchFailed(format!("Status Code: {}", status))),
         }
     } else {
         Err(YahooError::ConnectionFailed)
@@ -87,7 +102,7 @@ mod tests {
 
     #[test]
     fn test_get_quote_history() {
-        let provider = YahooConnector::new();
+        let provider = YahooConnectorBlocking::new();
         let start = Utc.ymd(2020, 1, 1).and_hms_milli(0, 0, 0, 0);
         let end = Utc.ymd(2020, 1, 31).and_hms_milli(23, 59, 59, 999);
         let resp = provider.get_quote_history("AAPL", start, end).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! Use the `blocking` feature to get the previous behavior back: i.e. `yahoo_finance_api = {"version": "1.0", features = ["blocking"]}`.
 //!
 #![cfg_attr(
-    feature = "async",
+    not(feature = "blocking"),
     doc = "
 # Get the latest available quote:
 ```rust
@@ -76,20 +76,20 @@ fn main() {
 
     let mut apple_found = false;
     println!(\"All tickers found while searching for 'Apple':\");
-    for item in resp.quotes 
+    for item in resp.quotes
     {
         println!(\"{}\", item.symbol)
     }
 }
 ```
-Some fields like `longname` are only optional and will be replaced by default 
-values if missing (e.g. empty string). If you do not like this behavior, 
-use `search_ticker_opt` instead which contains `Option<String>` fields, 
+Some fields like `longname` are only optional and will be replaced by default
+values if missing (e.g. empty string). If you do not like this behavior,
+use `search_ticker_opt` instead which contains `Option<String>` fields,
 returning `None` if the field found missing in the response.
 "
 )]
 #![cfg_attr(
-    not(feature = "async"),
+    feature = "blocking",
     doc = "
 # Get the latest available quote (with blocking feature enabled):
 ```rust
@@ -153,7 +153,7 @@ fn main() {
 
     let mut apple_found = false;
     println!(\"All tickers found while searching for 'Apple':\");
-    for item in resp.quotes 
+    for item in resp.quotes
     {
         println!(\"{}\", item.symbol)
     }
@@ -167,6 +167,7 @@ use chrono::{DateTime, Utc};
 mod quotes;
 mod search_result;
 mod yahoo_error;
+
 pub use quotes::{
     AdjClose, PeriodInfo, Quote, QuoteBlock, QuoteList, TradingPeriod, YChart, YMetaData,
     YQuoteBlock, YResponse,
@@ -194,25 +195,14 @@ macro_rules! YTICKER_QUERY {
     };
 }
 
-/// Container for connection parameters to yahoo! finance server
-#[derive(Default)]
-pub struct YahooConnector {
-    url: &'static str,
-    search_url: &'static str,
-}
-
-impl YahooConnector {
-    /// Constructor for a new instance of the yahoo  connector.
-    pub fn new() -> YahooConnector {
-        YahooConnector {
-            url: YCHART_URL,
-            search_url: YSEARCH_URL,
-        }
-    }
-}
-
 #[cfg(feature = "async")]
 pub mod async_impl;
 
 #[cfg(feature = "blocking")]
 pub mod blocking_impl;
+
+#[cfg(not(feature = "blocking"))]
+pub type YahooConnector = async_impl::YahooConnectorAsync;
+
+#[cfg(feature = "blocking")]
+pub type YahooConnector = blocking_impl::YahooConnectorBlocking;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //! Use the `blocking` feature to get the previous behavior back: i.e. `yahoo_finance_api = {"version": "1.0", features = ["blocking"]}`.
 //!
 #![cfg_attr(
-    not(feature = "blocking"),
+    feature = "async",
     doc = "
 # Get the latest available quote:
 ```rust
@@ -89,7 +89,7 @@ returning `None` if the field found missing in the response.
 "
 )]
 #![cfg_attr(
-    feature = "blocking",
+    not(feature = "async"),
     doc = "
 # Get the latest available quote (with blocking feature enabled):
 ```rust
@@ -163,7 +163,6 @@ fn main() {
 )]
 
 use chrono::{DateTime, Utc};
-use reqwest::StatusCode;
 
 mod quotes;
 mod search_result;
@@ -212,7 +211,7 @@ impl YahooConnector {
     }
 }
 
-#[cfg(not(feature = "blocking"))]
+#[cfg(feature = "async")]
 pub mod async_impl;
 
 #[cfg(feature = "blocking")]


### PR DESCRIPTION
(Based on the branch at #11, this should not be merged before the base branch)

This PR makes those changes:
- Replace the `reqwest` blocking client with `ureq`, which is a lot lighter (~100 crates less)
- Add the `async` feature, for users to be able to remove the async deps when using the blocking client
  - The `async` feature is added in the default features, so that it isn't a breaking change
- Use different structs for the blocking and async features
  - This is necessary to avoid the "multiple implementation" compile error
  - To avoid a breaking change, export `YahooConnector` as either:
    - The async version if the `blocking` feature is not present
    - The blocking version if the `async` feature is present