### PR TITLE
support for market events (splits and dividends)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yahoo_finance_api"
-version = "1.1.5"
+version = "1.2.0"
 authors = ["Mark Beinker <mwb@quantlink.de>", "Claus Matzinger <claus.matzinger+kb@gmail.com>"]
 edition = "2018"
 description = "A rust adapter for the yahoo! finance API to fetch histories of market data quotes."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,12 +181,12 @@ const YSEARCH_URL: &str = "https://query2.finance.yahoo.com/v1/finance/search";
 // Macros instead of constants,
 macro_rules! YCHART_PERIOD_QUERY {
     () => {
-        "{url}/{symbol}?symbol={symbol}&period1={start}&period2={end}&interval={interval}"
+        "{url}/{symbol}?symbol={symbol}&period1={start}&period2={end}&interval={interval}&events=div|split"
     };
 }
 macro_rules! YCHART_RANGE_QUERY {
     () => {
-        "{url}/{symbol}?symbol={symbol}&interval={interval}&range={range}"
+        "{url}/{symbol}?symbol={symbol}&interval={interval}&range={range}&events=div|split"
     };
 }
 macro_rules! YTICKER_QUERY {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ mod search_result;
 mod yahoo_error;
 pub use quotes::{
     AdjClose, PeriodInfo, Quote, QuoteBlock, QuoteList, TradingPeriod, YChart, YMetaData,
-    YQuoteBlock, YResponse,
+    YQuoteBlock, YResponse, Split, Dividend
 };
 pub use search_result::{YNewsItem, YQuoteItem, YQuoteItemOpt, YSearchResult, YSearchResultOpt};
 pub use yahoo_error::YahooError;

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -242,12 +242,12 @@ pub struct Split {
     /// wherever you had one before the split. (Here the numerator is 1 and 
     /// denom is 5). A reverse split is considered as nothing but a regular 
     /// split with a numerator > denom.
-    pub numerator: u8,
+    pub numerator: u64,
     /// Denominator of the split. For instance a 1:5 split means you get 5 share
     /// wherever you had one before the split. (Here the numerator is 1 and 
     /// denom is 5). A reverse split is considered as nothing but a regular 
     /// split with a numerator > denom.
-    pub denominator: u8,
+    pub denominator: u64,
     /// A textual representation of the split.
     #[serde(rename = "splitRatio")]
     pub split_ratio: String,

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::Deserialize;
 
 use super::YahooError;
@@ -68,6 +70,33 @@ impl YResponse {
         }
         Ok(quotes)
     }
+
+    /// This method retrieves information about the splits that might have
+    /// occured during the considered time period
+    pub fn splits(&self) -> Result<Vec<Split>, YahooError> {
+        self.check_consistency()?;
+        let stock = &self.chart.result[0];
+        if let Some(events) = &stock.events {
+            if let Some(splits) = &events.splits {
+                return Ok(splits.values().cloned().collect());
+            }
+        }
+        Ok(vec![])
+    }
+    /// This method retrieves information about the dividends that have
+    /// been recorded during the considered time period. 
+    ///
+    /// Note: Date is the ex-dividend date)
+    pub fn dividends(&self) -> Result<Vec<Dividend>, YahooError> {
+        self.check_consistency()?;
+        let stock = &self.chart.result[0];
+        if let Some(events) = &stock.events {
+            if let Some(dividends) = &events.dividends {
+                return Ok(dividends.values().cloned().collect());
+            }
+        }
+        Ok(vec![])
+    }
 }
 
 /// Struct for single quote
@@ -92,6 +121,7 @@ pub struct YChart {
 pub struct YQuoteBlock {
     pub meta: YMetaData,
     pub timestamp: Vec<u64>,
+    pub events: Option<EventsBlock>,
     pub indicators: QuoteBlock,
 }
 
@@ -191,4 +221,39 @@ pub struct QuoteList {
     pub close: Vec<Option<f64>>,
     pub low: Vec<Option<f64>>,
     pub open: Vec<Option<f64>>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct EventsBlock {
+    pub splits: Option<HashMap<u64, Split>>,
+    pub dividends: Option<HashMap<u64, Dividend>>,
+}
+
+/// This structure simply models a split that has occured.
+#[derive(Deserialize, Debug, Clone)]
+pub struct Split {
+    /// This is the date (timestamp) when the split occured
+    pub date: u64,
+    /// Numerator of the split. For instance a 1:5 split means you get 5 share
+    /// wherever you had one before the split. (Here the numerator is 1 and 
+    /// denom is 5). A reverse split is considered as nothing but a regular 
+    /// split with a numerator > denom.
+    pub numerator: u8,
+    /// Denominator of the split. For instance a 1:5 split means you get 5 share
+    /// wherever you had one before the split. (Here the numerator is 1 and 
+    /// denom is 5). A reverse split is considered as nothing but a regular 
+    /// split with a numerator > denom.
+    pub denominator: u8,
+    /// A textual representation of the split.
+    #[serde(rename = "splitRatio")]
+    pub split_ratio: String,
+}
+
+/// This structure simply models a dividend which has been recorded.
+#[derive(Deserialize, Debug, Clone)]
+pub struct Dividend {
+    /// This is the price of the dividend
+    pub amount: f64,
+    /// This is the ex-dividend date
+    pub date: u64,
 }

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -78,7 +78,9 @@ impl YResponse {
         let stock = &self.chart.result[0];
         if let Some(events) = &stock.events {
             if let Some(splits) = &events.splits {
-                return Ok(splits.values().cloned().collect());
+                let mut data = splits.values().cloned().collect::<Vec<Split>>();
+                data.sort_unstable_by_key(|d| d.date);
+                return Ok(data);
             }
         }
         Ok(vec![])
@@ -92,7 +94,9 @@ impl YResponse {
         let stock = &self.chart.result[0];
         if let Some(events) = &stock.events {
             if let Some(dividends) = &events.dividends {
-                return Ok(dividends.values().cloned().collect());
+                let mut data = dividends.values().cloned().collect::<Vec<Dividend>>();
+                data.sort_unstable_by_key(|d| d.date);
+                return Ok(data);
             }
         }
         Ok(vec![])


### PR DESCRIPTION
For a project of mine I needed to be able to fetch the market events information (splits and dividends). That information is displayed on the web but it was not available through `yahoo_finance_api`. The patch I propose simply fills this gap.

Hope you'll like it. Thanks a lot for the crate anyways ! :-)  

Here is an example of how it is used:
```rust
// To make a request, nothing changes from what you're used to.
let conn   = yahoo::YahooConnector::new();
let tick   = "TSLA";
let start  = DateTime::parse_from_rfc3339("2020-08-30T00:00:00.00Z")?.with_timezone(&Utc);
let end    = DateTime::parse_from_rfc3339("2020-09-02T00:00:00.00Z")?.with_timezone(&Utc);
let hist  = conn.get_quote_history(ticker, start, end).await?;

// Accessing the stocks does not change either
println!("{}", ticker);
println!("QUOTES");
for quote in hist.quotes()? {
    let time = DateTime::<Utc>::from(UNIX_EPOCH + Duration::from_secs(quote.timestamp));
    println!("{} | {:.2} | {:.2}", time, quote.open, quote.close);
}

// But in addition you can show the market events as you like
println!("SPLITS");
for split in hist.splits()? {
    let date = DateTime::<Utc>::from(UNIX_EPOCH + Duration::from_secs(split.date));
    println!("{} | {} : {}", date, split.numerator, split.denominator);
}
println!("DIVIDENDS");
for dividend in hist.dividends()? {
    let date = DateTime::<Utc>::from(UNIX_EPOCH + Duration::from_secs(dividend.date));
    println!("{} | {:.3}", date, dividend.amount);
}
```
