### PR TITLE
default-features (which includes openssl) are not necessary with rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["api-bindings"]
 include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json", "rustls"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "rustls-tls"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 chrono = "0.4"


### PR DESCRIPTION
Also, `rustls` doesn't appear to be a feature of `reqwest`, although `rustls-tls` is. (Maybe it changed?)

My reason for this PR:
The OpenSSL dependency makes it hard to cross-compile for aarch64 with musl.

I'm a bit new to Rust, but as far as I understand, I cannot disable features from the project. It must be done at the dependency with opt-in for optional features instead (https://stackoverflow.com/a/48687713). Thus this PR.