### PR TITLE
fix: support quote where firstTradeDate equal null

### DIFF
--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -114,7 +114,10 @@ mod tests {
 
         assert_eq!(&resp.chart.result[0].meta.symbol, "IBM");
         assert_eq!(&resp.chart.result[0].meta.data_granularity, "1d");
-        assert_eq!(&resp.chart.result[0].meta.first_trade_date, &-252322200);
+        assert_eq!(
+            &resp.chart.result[0].meta.first_trade_date,
+            &Some(-252322200)
+        );
 
         let _ = resp.last_quote().unwrap();
     }
@@ -229,6 +232,17 @@ mod tests {
         let response = tokio_test::block_on(provider.get_latest_quotes("VTSAX", "1d")).unwrap();
 
         assert_eq!(&response.chart.result[0].meta.symbol, "VTSAX");
+        assert_eq!(&response.chart.result[0].meta.range, "1mo");
+        assert_eq!(&response.chart.result[0].meta.data_granularity, "1d");
+        let _ = response.last_quote().unwrap();
+    }
+
+    #[test]
+    fn test_mutual_fund_latest_with_null_first_trade_date() {
+        let provider = YahooConnector::new();
+        let response = tokio_test::block_on(provider.get_latest_quotes("SIWA.F", "1d")).unwrap();
+
+        assert_eq!(&response.chart.result[0].meta.symbol, "SIWA.F");
         assert_eq!(&response.chart.result[0].meta.range, "1mo");
         assert_eq!(&response.chart.result[0].meta.data_granularity, "1d");
         let _ = response.last_quote().unwrap();

--- a/src/blocking_impl.rs
+++ b/src/blocking_impl.rs
@@ -106,7 +106,10 @@ mod tests {
 
         assert_eq!(&resp.chart.result[0].meta.symbol, "IBM");
         assert_eq!(&resp.chart.result[0].meta.data_granularity, "1d");
-        assert_eq!(&resp.chart.result[0].meta.first_trade_date, &-252322200);
+        assert_eq!(
+            &resp.chart.result[0].meta.first_trade_date,
+            &Some(-252322200)
+        );
 
         let _ = resp.last_quote().unwrap();
     }

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -132,7 +132,8 @@ pub struct YMetaData {
     pub symbol: String,
     pub exchange_name: String,
     pub instrument_type: String,
-    pub first_trade_date: i32,
+    #[serde(default)]
+    pub first_trade_date: Option<i32>,
     pub regular_market_time: u32,
     pub gmtoffset: i32,
     pub timezone: String,


### PR DESCRIPTION
Make the "firstTradeDate" key optional as it is returned as a null value for the symbol SIWA.F. This means that the first_trade_date field of the YMetaData struct is now Option<i32> instead of i32.