### PR TITLE
Custom Client Constructors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,12 +232,35 @@ impl YahooConnector {
             search_url: YSEARCH_URL,
         }
     }
+    
+    /// Constructs a new instance of the object.
+    ///
+    /// # Parameters
+    /// - `url`: Proxy url
+    /// - `auth`: Opt(username, password)
+    /// # Example
+    /// ```
+    /// use yahoo_finance_api as yf;
+    /// let instance = yf::YahooConnector::new_w_proxy(
+    ///   "https://secure.example", 
+    ///   Some(("user123", "password123"))
+    /// );
+    /// ```
+    pub fn new_w_proxy(url: &str, auth: Option<(&str, &str)>) -> Result<Self, YahooError> {
+        let client = if auth.is_some() {
+            let auth = auth.expect("Conditioned");
+            let proxy = reqwest::Proxy::all(url)?
+                .basic_auth(auth.0, auth.1);
 
-    pub fn new_w_proxy(url: &str) -> Result<Self, YahooError> {
-        let client = reqwest::Client::builder()
+            reqwest::Client::builder()
+                .proxy(proxy)
+                .build()?
+        } else {
+            reqwest::Client::builder()
             .proxy(reqwest::Proxy::all(url)?)
-            .build()?;
-        
+            .build()?
+        };
+            
         Ok(YahooConnector {
             client,
             url: YCHART_URL,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,8 +301,6 @@ impl YahooConnectorBuilder {
         })
     }
 
-    
-
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.inner = self.inner.timeout(timeout);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,14 @@ impl YahooConnector {
         }
     }
 
+    pub fn new_w_client(client: Client) -> Self {
+        YahooConnector {
+            client,
+            url: YCHART_URL,
+            search_url: YSEARCH_URL,
+        }
+    }
+
     pub fn builder() -> YahooConnectorBuilder {
         YahooConnectorBuilder {
             inner: Client::builder(),
@@ -256,6 +264,8 @@ impl YahooConnectorBuilder {
             search_url: YSEARCH_URL,
         })
     }
+
+    
 
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.inner = self.inner.timeout(timeout);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,6 +233,19 @@ impl YahooConnector {
         }
     }
 
+    pub fn new_w_proxy(url: &str) -> Result<Self, YahooError> {
+        let client = reqwest::Client::builder()
+            .proxy(reqwest::Proxy::all(url)?)
+            .build()?;
+        
+        Ok(YahooConnector {
+            client,
+            url: YCHART_URL,
+            search_url: YSEARCH_URL,
+        })
+
+    }
+
     pub fn new_w_client(client: Client) -> Self {
         YahooConnector {
             client,


### PR DESCRIPTION
Added two new YahooConnector constructors. One using a parameter passed client, giving the user complete discretion over the client build. The second a shortcut to create a proxy-tunneled client. 

After a week or so testing I ran into persistent 429 responses, setting the user agent fixed this for me. I assume the proxy would as well but didn't try it. 