### PR TITLE
Remove features that do not exist.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,5 @@ tokio-test = "0.4"
 tokio = { version = "1.7", features = ["macros", "rt-multi-thread"] }
 
 [features]
-blocking = ["reqwest/blocking"]
-decimal = ["rust_decimal"]
+blocking = []
+decimal = []


### PR DESCRIPTION
I was able to enable a feature that otherwise would not exist and it did nothing: i.e. `rust_decimal`.