### PR TITLE
Disable the feature rust_decimal.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ tokio = { version = "1.7", features = ["macros", "rt-multi-thread"] }
 
 [features]
 blocking = ["reqwest/blocking"]
-decimal = ["rust_decimal"]
+decimal = ["dep:rust_decimal"]


### PR DESCRIPTION
Starting with rust version `1.60` you can disable the feature by putting a `dep:` before it. Since the MSRV is `1.70`, this is safe to include.