### PR TITLE
Change edition to 2021.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Mark Beinker <mwb@quantlink.de>",
     "Claus Matzinger <claus.matzinger+kb@gmail.com>",
 ]
-edition = "2018"
+edition = "2021"
 description = "A rust adapter for the yahoo! finance API to fetch histories of market data quotes."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/xemwebe/yahoo_finance_api"


### PR DESCRIPTION
Since the MSRV is 1.170 and there are no errors when doing so, you might as well change the edition to 2021 to get the most recent version that is supported.