### PR TITLE
Add Sector and Technology Data (Issue  #45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +226,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -595,6 +633,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +759,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +782,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
 ]
 
 [[package]]
@@ -848,6 +908,8 @@ checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1204,6 +1266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ include = ["src/**/*", "LICENSE-*", "README.md"]
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
+    "cookies"
 ] }
 rust_decimal = { version = "1.36", optional = true }
 serde_json = "1.0"

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -101,7 +101,7 @@ impl YahooConnector {
     }
 
     // Get symbol metadata
-    pub async fn get_ticker_info(&mut self, symbol: &str) -> Result<YQuoteSummary, YahooError> {
+    pub async fn get_ticker_info(symbol: &str) -> Result<YQuoteSummary, YahooError> {
         let get_cookie_resp = reqwest::get(Y_GET_COOKIE_URL).await.unwrap();
         let cookie = get_cookie_resp
             .headers()
@@ -351,8 +351,7 @@ mod tests {
 
     #[test]
     fn test_get_ticker_info() {
-        let mut provider = YahooConnector::new().unwrap();
-        let result = tokio_test::block_on(provider.get_ticker_info("AAPL"));
+        let result = tokio_test::block_on(YahooConnector::get_ticker_info("AAPL"));
 
         assert!(result.is_ok());
         let quote_summary = result.unwrap().quote_summary;

--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -143,7 +143,6 @@ impl YahooConnector {
             .await
             .unwrap();
         let result = resp.json().await.unwrap();
-
         Ok(result)
     }
 
@@ -356,7 +355,7 @@ mod tests {
         let result = tokio_test::block_on(provider.get_ticker_info("AAPL"));
 
         assert!(result.is_ok());
-        assert!("Cupertino" == result.unwrap().quoteSummary.result[0].assetProfile.city);
-        // Testing it retrieved info, hard coded but shouldn't change soon
+        let quote_summary = result.unwrap().quote_summary;
+        assert!("Cupertino" == quote_summary.result[0].asset_profile.city); // Testing it retrieved info, hard coded but shouldn't change anytime soon
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,6 @@ pub use yahoo_error::YahooError;
 
 const YCHART_URL: &str = "https://query1.finance.yahoo.com/v8/finance/chart";
 const YSEARCH_URL: &str = "https://query2.finance.yahoo.com/v1/finance/search";
-const YQUOTESUMMARY_URL: &str = "";
 const Y_GET_COOKIE_URL: &str = "https://fc.yahoo.com";
 const Y_GET_CRUMB_URL: &str = "https://query1.finance.yahoo.com/v1/test/getcrumb";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,13 @@ pub use yahoo_error::YahooError;
 
 const YCHART_URL: &str = "https://query1.finance.yahoo.com/v8/finance/chart";
 const YSEARCH_URL: &str = "https://query2.finance.yahoo.com/v1/finance/search";
+const YQUOTESUMMARY_URL: &str = "";
+const Y_GET_COOKIE_URL: &str = "https://fc.yahoo.com";
+const Y_GET_CRUMB_URL: &str = "https://query1.finance.yahoo.com/v1/test/getcrumb";
+
+// special yahoo hardcoded keys and headers
+const Y_COOKIE_REQUEST_HEADER: &str = "set-cookie";
+const USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
 
 // Macros instead of constants,
 macro_rules! YCHART_PERIOD_QUERY {
@@ -208,6 +215,11 @@ macro_rules! YTICKER_QUERY {
     () => {
         "{url}?q={name}"
     };
+}
+macro_rules! YQUOTE_SUMMARY_QUERY {
+    () => {
+        "https://query2.finance.yahoo.com/v10/finance/quoteSummary/{symbol}?modules=financialData,quoteType,defaultKeyStatistics,assetProfile,summaryDetail&corsDomain=finance.yahoo.com&formatted=false&symbol={symbol}&crumb={crumb}"
+    }
 }
 
 /// Container for connection parameters to yahoo! finance server
@@ -247,7 +259,7 @@ impl Default for YahooConnector {
 
 impl YahooConnectorBuilder {
     pub fn build(self) -> Result<YahooConnector, YahooError> {
-        self.build_with_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36")
+        self.build_with_agent(USER_AGENT)
     }
 
     pub fn build_with_agent(self, user_agent: &str) -> Result<YahooConnector, YahooError> {

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -377,12 +377,13 @@ pub struct CapitalGain {
 
 #[derive(Deserialize, Debug)]
 pub struct YQuoteSummary {
-    pub quoteSummary: QuoteSummary,
+    #[serde(rename = "quoteSummary")]
+    pub quote_summary: ExtendedQuoteSummary,
 }
 
 #[derive(Deserialize, Debug)]
-pub struct QuoteSummary {
-    pub result: Vec<ResultData>,
+pub struct ExtendedQuoteSummary {
+    pub result: Vec<YSummaryData>,
     pub error: Option<serde_json::Value>,
 }
 
@@ -393,12 +394,17 @@ impl YQuoteSummary {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct ResultData {
-    pub assetProfile: AssetProfile,
-    pub summaryDetail: SummaryDetail,
-    pub defaultKeyStatistics: DefaultKeyStatistics,
-    pub quoteType: QuoteType,
-    pub financialData: FinancialData,
+pub struct YSummaryData {
+    #[serde(rename = "assetProfile")]
+    pub asset_profile: AssetProfile,
+    #[serde(rename = "summaryDetail")]
+    pub summary_detail: SummaryDetail,
+    #[serde(rename = "defaultKeyStatistics")]
+    pub default_key_statistics: DefaultKeyStatistics,
+    #[serde(rename = "quoteType")]
+    pub quote_type: QuoteType,
+    #[serde(rename = "financialData")]
+    pub financial_data: FinancialData,
 }
 
 #[derive(Deserialize, Debug)]
@@ -412,9 +418,12 @@ pub struct AssetProfile {
     pub website: String,
     pub industry: String,
     pub sector: String,
-    pub longBusinessSummary: String,
-    pub fullTimeEmployees: u32,
-    pub companyOfficers: Vec<CompanyOfficer>,
+    #[serde(rename = "longBusinessSummary")]
+    pub long_business_summary: String,
+    #[serde(rename = "fullTimeEmployees")]
+    pub full_time_employees: u32,
+    #[serde(rename = "companyOfficers")]
+    pub company_officers: Vec<CompanyOfficer>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -422,51 +431,69 @@ pub struct CompanyOfficer {
     pub name: String,
     pub age: Option<u32>,
     pub title: String,
-    pub yearBorn: Option<u32>,
-    pub fiscalYear: u32,
-    pub totalPay: Option<ValueWrapper>,
+    #[serde(rename = "yearBorn")]
+    pub year_born: Option<u32>,
+    #[serde(rename = "fiscalYear")]
+    pub fiscal_year: u32,
+    #[serde(rename = "totalPay")]
+    pub total_pay: Option<ValueWrapper>,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct ValueWrapper {
     pub raw: Option<u64>,
     pub fmt: Option<String>,
-    pub longFmt: Option<String>,
+    #[serde(rename = "longFmt")]
+    pub long_fmt: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct SummaryDetail {
-    pub previousClose: f64,
+    #[serde(rename = "previousClose")]
+    pub previous_close: f64,
     pub open: f64,
-    pub dayLow: f64,
-    pub dayHigh: f64,
-    pub regularMarketVolume: u64,
-    pub marketCap: u64,
+    #[serde(rename = "dayLow")]
+    pub day_low: f64,
+    #[serde(rename = "dayHigh")]
+    pub day_high: f64,
+    #[serde(rename = "regularMarketVolume")]
+    pub regular_market_volume: u64,
+    #[serde(rename = "marketCap")]
+    pub market_cap: u64,
     pub currency: String,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct DefaultKeyStatistics {
-    pub enterpriseValue: u64,
-    pub profitMargins: f64,
-    pub sharesOutstanding: u64,
+    #[serde(rename = "enterpriseValue")]
+    pub enterprise_value: u64,
+    #[serde(rename = "profitMargins")]
+    pub profit_margins: f64,
+    #[serde(rename = "sharesOutstanding")]
+    pub shares_outstanding: u64,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct QuoteType {
     pub exchange: String,
     pub symbol: String,
-    pub longName: String,
-    pub timeZoneFullName: String,
+    #[serde(rename = "longName")]
+    pub long_name: String,
+    #[serde(rename = "timeZoneFullName")]
+    pub timezone_full_name: String,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct FinancialData {
-    pub currentPrice: f64,
-    pub totalCash: u64,
+    #[serde(rename = "currentPrice")]
+    pub current_price: f64,
+    #[serde(rename = "totalCash")]
+    pub total_cash: u64,
     pub ebitda: u64,
-    pub totalDebt: u64,
-    pub totalRevenue: u64,
+    #[serde(rename = "totalDebt")]
+    pub total_debt: u64,
+    #[serde(rename = "totalRevenue")]
+    pub total_revenue: u64,
 }
 
 #[cfg(test)]

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -375,6 +375,100 @@ pub struct CapitalGain {
     pub date: u64,
 }
 
+#[derive(Deserialize, Debug)]
+pub struct YQuoteSummary {
+    pub quoteSummary: QuoteSummary,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct QuoteSummary {
+    pub result: Vec<ResultData>,
+    pub error: Option<serde_json::Value>,
+}
+
+impl YQuoteSummary {
+    pub fn from_json(json: serde_json::Value) -> Result<YQuoteSummary, YahooError> {
+        Ok(serde_json::from_value(json)?)
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ResultData {
+    pub assetProfile: AssetProfile,
+    pub summaryDetail: SummaryDetail,
+    pub defaultKeyStatistics: DefaultKeyStatistics,
+    pub quoteType: QuoteType,
+    pub financialData: FinancialData,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct AssetProfile {
+    pub address1: String,
+    pub city: String,
+    pub state: String,
+    pub zip: String,
+    pub country: String,
+    pub phone: String,
+    pub website: String,
+    pub industry: String,
+    pub sector: String,
+    pub longBusinessSummary: String,
+    pub fullTimeEmployees: u32,
+    pub companyOfficers: Vec<CompanyOfficer>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct CompanyOfficer {
+    pub name: String,
+    pub age: Option<u32>,
+    pub title: String,
+    pub yearBorn: Option<u32>,
+    pub fiscalYear: u32,
+    pub totalPay: Option<ValueWrapper>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ValueWrapper {
+    pub raw: Option<u64>,
+    pub fmt: Option<String>,
+    pub longFmt: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct SummaryDetail {
+    pub previousClose: f64,
+    pub open: f64,
+    pub dayLow: f64,
+    pub dayHigh: f64,
+    pub regularMarketVolume: u64,
+    pub marketCap: u64,
+    pub currency: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct DefaultKeyStatistics {
+    pub enterpriseValue: u64,
+    pub profitMargins: f64,
+    pub sharesOutstanding: u64,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct QuoteType {
+    pub exchange: String,
+    pub symbol: String,
+    pub longName: String,
+    pub timeZoneFullName: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct FinancialData {
+    pub currentPrice: f64,
+    pub totalCash: u64,
+    pub ebitda: u64,
+    pub totalDebt: u64,
+    pub totalRevenue: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
I made this a draft because its not in its final form, but I wanted to get a PR going since it currently works.  That way if life gets busy and I leave this PR, someone else can take over.

So some notes on how this currently works:

I tried to build it to parse just like the rest of the data in this library.

**So why is it not using the internal client or building a new client?**

This is because we need to use some async functions to get a crumb and cookie, otherwise yahoo will not give us the data.  Since this is async, I can't put it in the normal build code without making that stuff also async.  So instead it is a separate function that is static.

If you don't use those async functions to get a cookie to get the crumb, or you try to request without a crumb, you will get this:
`{"finance":{"result":null,"error":{"code":"Unauthorized","description":"Invalid Crumb"}}}`


### --- extra stuff I am including in case people need info on this in the future ---

**How does the yahoo finance API work?**

I reverse engineered it a bit and I am happy to throw this into a markdown if people want.  Basically you get a session cookie and use that to get a session crumb, then you need to hold that in the URL to get any of this data.  Here is a (very messy) test script I used that let me figure this out:

```rust
#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {

    let get_cookie_resp = reqwest::get("https://fc.yahoo.com").await?;
    let cookie = get_cookie_resp.headers().get("set-cookie");

    let client_builder = Client::builder();
    let jar = Arc::new(Jar::default());
    let crumb_url = Url::parse("https://query1.finance.yahoo.com/v1/test/getcrumb");
    jar.add_cookie_str(cookie.unwrap().to_str().unwrap(), &crumb_url.clone().unwrap());

    let user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";

    let client = client_builder.user_agent(user_agent).cookie_provider(jar).build().unwrap();
    let resp = client.get(crumb_url.unwrap()).send().await?;
    let crumb = resp.text().await.unwrap();

    let jar2 = Arc::new(Jar::default());
    let url_for_information = Url::parse(&("https://query2.finance.yahoo.com/v10/finance/quoteSummary/AAPL?modules=financialData,quoteType,defaultKeyStatistics,assetProfile,summaryDetail&corsDomain=finance.yahoo.com&formatted=false&symbol=APPL&".to_owned() + &("crumb=".to_owned() + &crumb)));
    jar2.add_cookie_str(cookie.unwrap().to_str().unwrap(), &url_for_information.clone().unwrap());

    let second_client = Client::builder().user_agent(user_agent).cookie_provider(jar2).build().unwrap();
    let resp = second_client.get(url_for_information.unwrap()).send().await?;

    // println!("{resp:#?}");
    println!("{}", resp.text().await?);

    Ok(())
}
```

^ I imagine we might want to keep this somewhere in case yahoo changes there api.  So we have something to test with and figure out the new API.