### PR TITLE
YMetaData: add new fields

### DIFF
--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -168,8 +168,11 @@ pub struct YQuoteBlock {
 pub struct YMetaData {
     pub currency: Option<String>,
     pub symbol: String,
-    pub exchange_name: String,
+    pub long_name: String,
+    pub short_name: String,
     pub instrument_type: String,
+    pub exchange_name: String,
+    pub full_exchange_name: String,
     #[serde(default)]
     pub first_trade_date: Option<i32>,
     pub regular_market_time: u32,
@@ -179,6 +182,12 @@ pub struct YMetaData {
     pub regular_market_price: Decimal,
     pub chart_previous_close: Decimal,
     pub previous_close: Option<Decimal>,
+    pub has_pre_post_market_data: bool,
+    pub fifty_two_week_high: Decimal,
+    pub fifty_two_week_low: Decimal,
+    pub regular_market_day_high: Decimal,
+    pub regular_market_day_low: Decimal,
+    pub regular_market_volume: Decimal,
     #[serde(default)]
     pub scale: Option<i32>,
     pub price_hint: i32,

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -185,9 +185,9 @@ pub struct YMetaData {
     pub has_pre_post_market_data: bool,
     pub fifty_two_week_high: Decimal,
     pub fifty_two_week_low: Decimal,
-    pub regular_market_day_high: Decimal,
-    pub regular_market_day_low: Decimal,
-    pub regular_market_volume: Decimal,
+    pub regular_market_day_high: Option<Decimal>,
+    pub regular_market_day_low: Option<Decimal>,
+    pub regular_market_volume: Option<Decimal>,
     #[serde(default)]
     pub scale: Option<i32>,
     pub price_hint: i32,


### PR DESCRIPTION
It looks like they added new fields, but I don't know which of them might be optional.

prof: https://query1.finance.yahoo.com/v8/finance/chart/AAPL?symbol=AAPL&interval=15m&range=1d&events=div|split|capitalGains