### PR TITLE
Custom client (reqwest)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,9 +164,9 @@ use time::OffsetDateTime;
 
 #[cfg(feature = "blocking")]
 use reqwest::blocking::{Client, ClientBuilder};
-use reqwest::StatusCode;
 #[cfg(not(feature = "blocking"))]
 use reqwest::{Client, ClientBuilder};
+use reqwest::{Proxy, StatusCode};
 
 // re-export time crate
 pub use quotes::decimal::Decimal;
@@ -271,13 +271,7 @@ impl YahooConnectorBuilder {
         self
     }
 
-    pub fn proxy(mut self, url: &str, auth: Option<(&str, &str)>) -> Self {
-        let mut proxy = reqwest::Proxy::all(url).unwrap();
-
-        if let Some((login, password)) = auth {
-            proxy = proxy.basic_auth(login, password);
-        }
-
+    pub fn proxy(mut self, proxy: Proxy) -> Self {
         self.inner = self.inner.proxy(proxy);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,15 +289,6 @@ impl YahooConnectorBuilder {
         })
     }
 
-    pub fn build_with_agent(user_agent: &str) -> Result<YahooConnector, YahooError> {
-        let client = Client::builder().user_agent(user_agent).build()?;
-
-        Ok(YahooConnector {
-            client,
-            ..Default::default()
-        })
-    }
-
     pub fn build_with_client(client: Client) -> Result<YahooConnector, YahooError> {
         Ok(YahooConnector {
             client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,9 +194,6 @@ const Y_GET_CRUMB_URL: &str = "https://query1.finance.yahoo.com/v1/test/getcrumb
 const Y_COOKIE_REQUEST_HEADER: &str = "set-cookie";
 const USER_AGENT: &str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
 
-// Default value for reqwest is 30 seconds
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
-
 // Macros instead of constants,
 macro_rules! YCHART_PERIOD_QUERY {
     () => {


### PR DESCRIPTION
* Fixed timeout method in YahooConnectorBuilder which never worked before. 
* Made YahooConnectorBuilder look like builder pattern.
* Removing self from build_with_agent (!)
* Add YahooConnectorBuilder::build_with_client()

and there is an option to add a method to YahooConnector, but it seems like it’s unnecessary and it’s not a fact that it gives performance (I’m not sure).
```rust
    pub fn replace_proxy_agent_timeout(
        self,
        url: &str,
        auth: Option<(&str, &str)>,
        user_agent: Option<&str>,
        timeout: Option<Duration>,
    ) -> Result<Self, YahooError> {
        let client_builder = Client::builder();

        let mut proxy = reqwest::Proxy::all(url)?;

        if let Some((login, password)) = auth {
            proxy = proxy.basic_auth(login, password);
        };

        let mut selected_user_agent = USER_AGENT;

        if let Some(user_agent) = user_agent {
            selected_user_agent = user_agent;
        }

        let mut selected_timeout = DEFAULT_TIMEOUT;

        if let Some(timeout) = timeout {
            selected_timeout = timeout;
        }

        let client = client_builder
            .user_agent(selected_user_agent)
            .proxy(proxy)
            .timeout(selected_timeout)
            .build()?;

        Ok(self)
    }
```