### PR TITLE
Improved get ticker info

### DIFF
--- a/src/async_impl.rs
+++ b/src/async_impl.rs
@@ -1,6 +1,3 @@
-use crate::quotes::YQuoteSummary;
-use search_result::YOptionChain;
-
 use super::*;
 
 impl YahooConnector {
@@ -60,6 +57,27 @@ impl YahooConnector {
         YResponse::from_json(self.send_request(&url).await?)
     }
 
+    /// Retrieve the quote history for the given ticker form date start to end (inclusive) and optionally before and after regular trading hours, if available; specifying the interval of the ticker.
+    pub async fn get_quote_history_interval_prepost(
+        &self,
+        ticker: &str,
+        start: OffsetDateTime,
+        end: OffsetDateTime,
+        interval: &str,
+        prepost: bool,
+    ) -> Result<YResponse, YahooError> {
+        let url = format!(
+            YCHART_PERIOD_QUERY_PRE_POST!(),
+            url = self.url,
+            symbol = ticker,
+            start = start.unix_timestamp(),
+            end = end.unix_timestamp(),
+            interval = interval,
+            prepost = prepost,
+        );
+        YResponse::from_json(self.send_request(&url).await?)
+    }
+
     /// Retrieve the quote history for the given ticker for a given period and ticker interval and optionally before and after regular trading hours
     pub async fn get_quote_period_interval(
         &self,
@@ -101,49 +119,135 @@ impl YahooConnector {
     }
 
     // Get symbol metadata
-    pub async fn get_ticker_info(symbol: &str) -> Result<YQuoteSummary, YahooError> {
-        let get_cookie_resp = reqwest::get(Y_GET_COOKIE_URL).await.unwrap();
-        let cookie = get_cookie_resp
+    pub async fn get_ticker_info(&mut self, symbol: &str) -> Result<YQuoteSummary, YahooError> {
+        if let None = &self.crumb {
+            self.crumb = Some(self.get_crumb().await?);
+        }
+        let cookie_provider = Arc::new(reqwest::cookie::Jar::default());
+        let url = reqwest::Url::parse(
+            &(format!(
+                YQUOTE_SUMMARY_QUERY!(),
+                symbol = symbol,
+                crumb = self.crumb.as_ref().unwrap()
+            )),
+        );
+
+        cookie_provider.add_cookie_str(&self.cookie.clone().unwrap(), &url.clone().unwrap());
+
+        let mut result: Result<YQuoteSummary, YahooError> = Err(YahooError::NoResponse);
+
+        let max_retries = 1;
+        for i in 0..=max_retries {
+            result = Ok(self
+                .create_client(Some(cookie_provider.clone()))
+                .await?
+                .get(url.clone().unwrap())
+                .send()
+                .await?
+                .json()
+                .await?);
+
+            if let Ok(result) = &result {
+                if let Some(finance) = &result.finance {
+                    if let Some(error) = &finance.error {
+                        if let Some(description) = &error.description {
+                            if description.contains("Invalid Crumb") {
+                                self.crumb = Some(self.get_crumb().await?);
+                                if i == max_retries {
+                                    return Err(YahooError::InvalidCrumb);
+                                }
+                            }
+                        }
+                        if let Some(code) = &error.code {
+                            if code.contains("Unauthorized") {
+                                println!("Unauthorized {:?}", i);
+                                self.crumb = Some(self.get_crumb().await?);
+                                if i == max_retries {
+                                    return Err(YahooError::Unauthorized);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Ok(result)
+        result
+    }
+
+    async fn get_crumb(&mut self) -> Result<String, YahooError> {
+        if let None = &self.cookie {
+            self.cookie = Some(self.get_cookie().await?);
+        }
+
+        let cookie_provider = Arc::new(reqwest::cookie::Jar::default());
+        cookie_provider.add_cookie_str(
+            &self.cookie.clone().unwrap(),
+            &reqwest::Url::parse(Y_GET_CRUMB_URL).unwrap(),
+        );
+
+        let mut result = Err(YahooError::NoResponse);
+
+        let max_retries = 1;
+        for i in 0..=max_retries {
+            result = Ok(self
+                .create_client(Some(cookie_provider.clone()))
+                .await?
+                .get(Y_GET_CRUMB_URL)
+                .send()
+                .await?
+                .text()
+                .await?);
+
+            if let Ok(result) = &result {
+                if result.contains("Invalid Cookie") {
+                    self.cookie = Some(self.get_cookie().await?);
+                    if i == max_retries {
+                        return Err(YahooError::InvalidCookie);
+                    }
+                }
+            }
+        }
+
+        // Ok(result)
+        result
+    }
+
+    async fn get_cookie(&mut self) -> Result<String, YahooError> {
+        Ok(self
+            .client
+            .get(Y_GET_COOKIE_URL)
+            .send()
+            .await?
             .headers()
             .get(Y_COOKIE_REQUEST_HEADER)
-            .unwrap()
+            .ok_or(YahooError::NoCookies)?
             .to_str()
-            .unwrap();
-        let jar_for_cookie = std::sync::Arc::new(reqwest::cookie::Jar::default());
-        jar_for_cookie.add_cookie_str(cookie, &reqwest::Url::parse(Y_GET_CRUMB_URL).unwrap());
-        let intermediate_client_for_cookie = Client::builder()
-            .user_agent(USER_AGENT)
-            .cookie_provider(jar_for_cookie)
-            .build()
-            .unwrap();
+            .map_err(|_| YahooError::InvisibleAsciiInCookies)?
+            .to_string())
+    }
 
-        let crumb = intermediate_client_for_cookie
-            .get(reqwest::Url::parse(Y_GET_CRUMB_URL).unwrap())
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
+    async fn create_client(
+        &mut self,
+        cookie_provider: Option<Arc<reqwest::cookie::Jar>>,
+    ) -> Result<Client, reqwest::Error> {
+        let mut client_builder = Client::builder();
 
-        let jar_for_info = std::sync::Arc::new(reqwest::cookie::Jar::default());
-        let url_for_information = reqwest::Url::parse(
-            &(format!(YQUOTE_SUMMARY_QUERY!(), symbol = symbol, crumb = crumb)),
-        );
-        jar_for_info.add_cookie_str(cookie, &url_for_information.clone().unwrap());
+        if let Some(cookie_provider) = cookie_provider {
+            client_builder = client_builder.cookie_provider(cookie_provider);
+        }
+        if let Some(timeout) = &self.timeout {
+            client_builder = client_builder.timeout(timeout.clone());
+        }
+        if let Some(user_agent) = &self.user_agent {
+            client_builder = client_builder.user_agent(user_agent.clone());
+        }
+        if let Some(proxy) = &self.proxy {
+            client_builder = client_builder.proxy(proxy.clone());
+        }
 
-        let client_for_info = reqwest::Client::builder()
-            .user_agent(USER_AGENT)
-            .cookie_provider(jar_for_info)
-            .build()
-            .unwrap();
-        let resp = client_for_info
-            .get(url_for_information.unwrap())
-            .send()
-            .await
-            .unwrap();
-        let result = resp.json().await.unwrap();
-        Ok(result)
+        client_builder.build()
     }
 
     /// Send request to yahoo! finance server and transform response to JSON value
@@ -351,10 +455,45 @@ mod tests {
 
     #[test]
     fn test_get_ticker_info() {
-        let result = tokio_test::block_on(YahooConnector::get_ticker_info("AAPL"));
+        let mut provider = YahooConnector::new().unwrap();
 
-        assert!(result.is_ok());
-        let quote_summary = result.unwrap().quote_summary;
-        assert!("Cupertino" == quote_summary.result[0].asset_profile.city); // Testing it retrieved info, hard coded but shouldn't change anytime soon
+        let result = tokio_test::block_on(provider.get_ticker_info("AAPL"));
+
+        let quote_summary = result.unwrap().quote_summary.unwrap();
+        assert!(
+            "Cupertino"
+                == quote_summary.result[0]
+                    .asset_profile
+                    .as_ref()
+                    .unwrap()
+                    .city
+                    .as_ref()
+                    .unwrap()
+        );
+        // Testing it retrieved info, hard coded but shouldn't change anytime soon
+    }
+
+    #[tokio::test]
+    async fn test_get_crumb() {
+        let mut provider = YahooConnector::new().unwrap();
+        let crumb = provider.get_crumb().await.unwrap();
+
+        assert!(crumb.len() > 5);
+        assert!(crumb.len() < 16);
+    }
+
+    #[tokio::test]
+    async fn test_get_cookie() {
+        let mut provider = YahooConnector::new().unwrap();
+        let cookie = provider.get_cookie().await.unwrap();
+
+        assert!(cookie.len() > 30);
+        assert!(
+            cookie.contains("Expires")
+                || cookie.contains("Max-Age")
+                || cookie.contains("Domain")
+                || cookie.contains("Path")
+                || cookie.contains("Secure")
+        );
     }
 }

--- a/src/yahoo_error.rs
+++ b/src/yahoo_error.rs
@@ -16,4 +16,16 @@ pub enum YahooError {
     DataInconsistency,
     #[error("construcing yahoo! finance client failed")]
     BuilderFailed,
+    #[error("No cookies in response headers")]
+    NoCookies,
+    #[error("Invisible characters in cookies")]
+    InvisibleAsciiInCookies,
+    #[error("No response")]
+    NoResponse,
+    #[error("Invalid cookie")]
+    InvalidCookie,
+    #[error("Unauthorized")]
+    Unauthorized,
+    #[error("Invalid crumb")]
+    InvalidCrumb,
 }


### PR DESCRIPTION
    YahooConnector now stores user-specified client data
    get_ticker_info is now a method that uses the data for the client specified by the user
    remove unwraps
    add blocking version
    add test

