### PR TITLE
Always use rustls TLS backend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,10 +265,11 @@ impl YahooConnector {
             ..Default::default()
         }
     }
-}
 
-impl Default for YahooConnector {
-    fn default() -> Self {
+    /// Internal default implementation used exclusively by the builder.
+    /// Note: This default implementation does not set the user agent in the client,
+    /// so it does not work on its own. The builder will set the user agent.
+    fn default_internal() -> Self {
         YahooConnector {
             client: Client::default(),
             url: YCHART_URL,
@@ -318,14 +319,14 @@ impl YahooConnectorBuilder {
             timeout: self.timeout,
             user_agent: self.user_agent,
             proxy: self.proxy,
-            ..Default::default()
+            ..YahooConnector::default_internal()
         })
     }
 
     pub fn build_with_client(client: Client) -> Result<YahooConnector, YahooError> {
         Ok(YahooConnector {
             client,
-            ..Default::default()
+            ..YahooConnector::default_internal()
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,7 @@ impl YahooConnectorBuilder {
         }
 
         Ok(YahooConnector {
-            client: self.inner.build()?,
+            client: self.inner.use_rustls_tls().build()?,
             timeout: self.timeout,
             user_agent: self.user_agent,
             proxy: self.proxy,


### PR DESCRIPTION
This fixes #76. Now always the same TLS backend is used (rustls) regardless of features the user might have enabled.

In addition, I made the default implementation of the YahooConnector private. Since the user agent is not set, it makes no sense for users to use it. However, it is still used internally.

Besides: @xemwebe What is your plan for publishing version 3.1.0 on crates.io?