### PR TITLE
feat: Add financial events API for earnings and corporate meetings

### DIFF
--- a/src/blocking_impl.rs
+++ b/src/blocking_impl.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::quotes::{FinancialEvent, YEarningsResponse, YErrorMessage};
 
 impl YahooConnector {
     /// Retrieve the quotes of the last day for the given ticker
@@ -158,6 +159,261 @@ impl YahooConnector {
         }
 
         Err(YahooError::NoResponse)
+    }
+
+    /// Retrieve earnings dates for the given ticker with specified limit (max limit: 250)
+    pub fn get_financial_events(
+        &mut self,
+        ticker: &str,
+        limit: u32,
+    ) -> Result<Vec<FinancialEvent>, YahooError> {
+        if ticker.is_empty() {
+            return Err(YahooError::FetchFailed(
+                "Ticker cannot be empty".to_string(),
+            ));
+        }
+
+        // Ensure we have crumb for authentication
+        if self.crumb.is_none() {
+            self.crumb = Some(self.get_crumb()?);
+        }
+        if self.cookie.is_none() {
+            self.cookie = Some(self.get_cookie()?);
+        }
+
+        let url = format!(
+            YEARNINGS_QUERY!(),
+            url = Y_EARNINGS_URL,
+            lang = "en-US",
+            region = "US",
+            crumb = self.crumb.as_ref().unwrap()
+        );
+
+        // Create request body
+        let query_body = serde_json::json!({
+            "size": limit,
+            "query": {
+                "operator": "eq",
+                "operands": ["ticker", ticker]
+            },
+            "sortField": "startdatetime",
+            "sortType": "DESC",
+            "entityIdType": "earnings",
+            "includeFields": [
+                "startdatetime",
+                "timeZoneShortName",
+                "epsestimate",
+                "epsactual",
+                "epssurprisepct",
+                "eventtype"
+            ]
+        });
+
+        // Setup cookie for authenticated request
+        let cookie_provider = Arc::new(reqwest::cookie::Jar::default());
+        let parsed_url = reqwest::Url::parse(&url).map_err(|_| YahooError::InvalidUrl)?;
+
+        if let Some(cookie) = &self.cookie {
+            cookie_provider.add_cookie_str(cookie, &parsed_url);
+        }
+
+        let max_retries = 1;
+        for attempt in 0..=max_retries {
+            let client = self.create_client(Some(cookie_provider.clone()))?;
+
+            let response = client
+                .post(&url)
+                .header("Content-Type", "application/json")
+                .json(&query_body)
+                .send()?;
+
+            let status = response.status();
+
+            match status {
+                reqwest::StatusCode::TOO_MANY_REQUESTS => {
+                    return Err(YahooError::TooManyRequests(format!(
+                        "POST {} in get_financial_events for ticker {}",
+                        Y_EARNINGS_URL, ticker
+                    )));
+                }
+                reqwest::StatusCode::UNAUTHORIZED => {
+                    if attempt < max_retries {
+                        self.crumb = Some(self.get_crumb()?);
+                        continue;
+                    } else {
+                        return Err(YahooError::Unauthorized);
+                    }
+                }
+                reqwest::StatusCode::FORBIDDEN => {
+                    return Err(YahooError::Unauthorized);
+                }
+                reqwest::StatusCode::NOT_FOUND => {
+                    return Err(YahooError::FetchFailed(format!(
+                        "Ticker {} not found",
+                        ticker
+                    )));
+                }
+                _ if !status.is_success() => {
+                    return Err(YahooError::FetchFailed(format!("HTTP error: {}", status)));
+                }
+                _ => {} // Success, continue
+            }
+
+            let text = response.text()?;
+
+            // Try to parse response
+            match serde_json::from_str::<YEarningsResponse>(&text) {
+                Ok(earnings_response) => {
+                    // Check for API errors
+                    if let Some(error) = &earnings_response.finance.error {
+                        let code = error.get("code").and_then(|v| v.as_str()).unwrap_or("");
+                        let description = error
+                            .get("description")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+
+                        // If the crumb is invalid, try to refetch it and retry the request
+                        if description.contains("Invalid Crumb") {
+                            if attempt < max_retries {
+                                self.crumb = Some(self.get_crumb()?); // Refetch crumb
+                                continue; // Go to the next iteration
+                            } else {
+                                return Err(YahooError::InvalidCrumb);
+                            }
+                        }
+
+                        return Err(YahooError::ApiError(YErrorMessage {
+                            code: Some(code.to_string()),
+                            description: Some(description.to_string()),
+                        }));
+                    }
+
+                    return Ok(self.parse_earnings_response(earnings_response)?);
+                }
+                Err(e) => {
+                    // A parsing error is a critical failure unless we are retrying.
+                    if attempt < max_retries {
+                        // It's possible the session expired, let's try refreshing the crumb and cookie.
+                        self.crumb = Some(self.get_crumb()?);
+                        continue;
+                    } else {
+                        // If parsing fails on the last attempt, return the error.
+                        return Err(YahooError::DeserializeFailed(e));
+                    }
+                }
+            }
+        }
+
+        Err(YahooError::NoResponse)
+    }
+
+    /// Parse earnings response into structured data
+    fn parse_earnings_response(
+        &self,
+        response: YEarningsResponse,
+    ) -> Result<Vec<FinancialEvent>, YahooError> {
+        let mut earnings_events = Vec::new();
+
+        if response.finance.result.is_empty() {
+            return Ok(earnings_events);
+        }
+
+        let result = &response.finance.result[0];
+        if result.documents.is_empty() {
+            return Ok(earnings_events);
+        }
+
+        let document = &result.documents[0];
+
+        if document.columns.is_empty() {
+            return Err(YahooError::DataInconsistency);
+        }
+
+        // Map column names to indices
+        let mut column_map = std::collections::HashMap::new();
+        for (index, column) in document.columns.iter().enumerate() {
+            column_map.insert(column.label.as_str(), index);
+        }
+
+        // Parse each row
+        for row in &document.rows {
+            let earnings_event = self.parse_earnings_row(row, &column_map)?;
+            earnings_events.push(earnings_event);
+        }
+
+        Ok(earnings_events)
+    }
+
+    /// Parse individual earnings row
+    fn parse_earnings_row(
+        &self,
+        row: &[serde_json::Value],
+        column_map: &std::collections::HashMap<&str, usize>,
+    ) -> Result<FinancialEvent, YahooError> {
+        // Extract earnings date
+        let get_value = |col_name: &str| column_map.get(col_name).and_then(|&idx| row.get(idx));
+
+        let earnings_date = match get_value("Event Start Date").and_then(|v| v.as_str()) {
+            Some(date_str) => {
+                OffsetDateTime::parse(date_str, &time::format_description::well_known::Rfc3339)
+                    .or_else(|_| {
+                        OffsetDateTime::parse(
+                            date_str,
+                            &time::format_description::well_known::Iso8601::DEFAULT,
+                        )
+                    })
+                    .map_err(|_| YahooError::InvalidDateFormat)?
+            }
+            None => return Err(YahooError::MissingField("Event Start Date".to_string())),
+        };
+
+        // Extract event type and convert codes
+        let event_type = get_value("Event Type")
+            .map(|v| {
+                if let Some(s) = v.as_str() {
+                    s.to_string()
+                } else if let Some(i) = v.as_i64() {
+                    i.to_string()
+                } else {
+                    "Unknown".to_string()
+                }
+            })
+            .unwrap_or_else(|| "Unknown".to_string());
+
+        let event_type = match event_type.as_str() {
+            "1" => "Call".to_string(),
+            "2" => "Earnings".to_string(),
+            "11" => "Meeting".to_string(),
+            other => other.to_string(),
+        };
+        let eps_estimate = get_value("EPS Estimate").and_then(|v| v.as_f64());
+        let reported_eps = get_value("Reported EPS").and_then(|v| v.as_f64());
+        let surprise_percent = get_value("Surprise (%)").and_then(|v| v.as_f64());
+        let timezone = get_value("Timezone short name")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        Ok(FinancialEvent {
+            earnings_date,
+            event_type,
+            eps_estimate,
+            reported_eps,
+            surprise_percent,
+            timezone,
+        })
+    }
+
+    /// Get only earnings events (filter out meetings)
+    pub fn get_earnings_only(
+        &mut self,
+        ticker: &str,
+        limit: u32,
+    ) -> Result<Vec<FinancialEvent>, YahooError> {
+        let all_events = self.get_financial_events(ticker, limit)?;
+        Ok(all_events
+            .into_iter()
+            .filter(|event| event.event_type == "Earnings")
+            .collect())
     }
 
     fn get_crumb(&mut self) -> Result<String, YahooError> {
@@ -548,5 +804,39 @@ mod tests {
         assert!(!quotes.is_err());
         let quotes = quotes.unwrap();
         assert_eq!(quotes.len(), 15939);
+    }
+
+    #[test]
+    fn test_get_earnings_dates() {
+        let mut provider = YahooConnector::new().unwrap();
+        let limit = 100;
+        let result = provider.get_financial_events("AAPL", limit);
+
+        if result.is_err() {
+            println!("{:?}", result);
+        }
+
+        assert!(result.is_ok());
+        let earnings = result.unwrap();
+
+        assert_eq!(earnings.len() as u32, limit);
+
+        assert!(!earnings.is_empty());
+    }
+
+    #[test]
+    fn test_get_earnings_only() {
+        let mut provider = YahooConnector::new().unwrap();
+        let result = provider.get_earnings_only("AAPL", 100);
+
+        assert!(result.is_ok());
+        let earnings = result.unwrap();
+
+        // All events should be earnings type
+        for event in &earnings {
+            assert_eq!(event.event_type, "Earnings");
+        }
+
+        println!("Earnings-only events: {}", earnings.len());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,9 +176,9 @@ mod search_result;
 mod yahoo_error;
 pub use quotes::{
     AdjClose, AssetProfile, CapitalGain, CurrentTradingPeriod, DefaultKeyStatistics, Dividend,
-    ExtendedQuoteSummary, FinancialData, PeriodInfo, Quote, QuoteBlock, QuoteList, QuoteType,
-    Split, SummaryDetail, TradingPeriods, YChart, YMetaData, YQuoteBlock, YQuoteSummary, YResponse,
-    YSummaryData,
+    ExtendedQuoteSummary, FinancialData, FinancialEvent, PeriodInfo, Quote, QuoteBlock, QuoteList,
+    QuoteType, Split, SummaryDetail, TradingPeriods, YChart, YMetaData, YQuoteBlock, YQuoteSummary,
+    YResponse, YSummaryData,
 };
 pub use search_result::{
     YNewsItem, YOptionChain, YOptionChainData, YOptionChainResult, YOptionContract, YOptionDetails,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,7 @@ const YCHART_URL: &str = "https://query1.finance.yahoo.com/v8/finance/chart";
 const YSEARCH_URL: &str = "https://query2.finance.yahoo.com/v1/finance/search";
 const Y_GET_COOKIE_URL: &str = "https://fc.yahoo.com";
 const Y_GET_CRUMB_URL: &str = "https://query1.finance.yahoo.com/v1/test/getcrumb";
+const Y_EARNINGS_URL: &str = "https://query1.finance.yahoo.com/v1/finance/visualization";
 
 // special yahoo hardcoded keys and headers
 const Y_COOKIE_REQUEST_HEADER: &str = "set-cookie";
@@ -225,6 +226,11 @@ macro_rules! YQUOTE_SUMMARY_QUERY {
     () => {
         "https://query2.finance.yahoo.com/v10/finance/quoteSummary/{symbol}?modules=financialData,quoteType,defaultKeyStatistics,assetProfile,summaryDetail&corsDomain=finance.yahoo.com&formatted=false&symbol={symbol}&crumb={crumb}"
     }
+}
+macro_rules! YEARNINGS_QUERY {
+    () => {
+        "{url}?lang={lang}&region={region}&crumb={crumb}"
+    };
 }
 
 /// Container for connection parameters to yahoo! finance server

--- a/src/quotes.rs
+++ b/src/quotes.rs
@@ -2,6 +2,7 @@ use serde::de::{self, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
+use time::OffsetDateTime;
 
 use super::YahooError;
 
@@ -739,6 +740,44 @@ pub struct FinancialData {
     pub operating_margins: Option<f64>,
     pub profit_margins: Option<f64>,
     pub financial_currency: Option<String>,
+}
+
+// Структуры для earnings dates response
+#[derive(Deserialize, Debug, Clone)]
+pub struct YEarningsResponse {
+    pub finance: YEarningsFinance,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct YEarningsFinance {
+    pub result: Vec<YEarningsResult>,
+    pub error: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct YEarningsResult {
+    pub documents: Vec<YEarningsDocument>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct YEarningsDocument {
+    pub columns: Vec<YEarningsColumn>,
+    pub rows: Vec<Vec<serde_json::Value>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct YEarningsColumn {
+    pub label: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FinancialEvent {
+    pub earnings_date: OffsetDateTime,
+    pub event_type: String,
+    pub eps_estimate: Option<f64>,
+    pub reported_eps: Option<f64>,
+    pub surprise_percent: Option<f64>,
+    pub timezone: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/yahoo_error.rs
+++ b/src/yahoo_error.rs
@@ -38,4 +38,13 @@ pub enum YahooError {
     InvalidCrumb,
     #[error("Too many requests (rate limited by Yahoo) during: {0}")]
     TooManyRequests(String),
+
+    #[error("Invalid URL format")]
+    InvalidUrl,
+
+    #[error("Invalid date format")]
+    InvalidDateFormat,
+
+    #[error("Missing required field: {0}")]
+    MissingField(String),
 }


### PR DESCRIPTION
### Summary
Adds support for retrieving financial events from Yahoo Finance, including earnings reports and corporate meetings.

### New Methods
- `get_financial_events(ticker, limit)` - All financial events
- `get_earnings_only(ticker, limit)` - Earnings reports only (filters out meetings)

### Key Features
- ✅ Retrieves earnings data with EPS estimates, actuals, and surprise %
- ✅ Handles authentication (cookie + crumb) with retry logic  
- ✅ Supports up to 250 events per request
- ✅ Comprehensive error handling for rate limits and auth issues

### Data Overview
Based on testing with AAPL (100 events):
- **99 Earnings reports** (1999-2025) with full EPS data
- **1 Corporate meeting** (2025 shareholder meeting)

### Usage
```rust
// Get all events
let events = provider.get_financial_events("AAPL", 100).await?;

// Get earnings only (recommended)
let earnings = provider.get_earnings_only("AAPL", 100).await?;
```

### Breaking Changes
None - purely additive feature.